### PR TITLE
Python 3 fixes

### DIFF
--- a/DeDRM_plugin/alfcrypto.py
+++ b/DeDRM_plugin/alfcrypto.py
@@ -207,8 +207,9 @@ def _load_python_alfcrypto():
 
         def ctx_init(self, key):
             ctx1 = 0x0CAFFE19E
-            for keyChar in key:
-                keyByte = ord(keyChar)
+            if isinstance(key, str):
+                key = key.encode('latin-1')
+            for keyByte in key:
                 ctx2 = ctx1
                 ctx1 = ((((ctx1 >>2) * (ctx1 >>7))&0xFFFFFFFF) ^ (keyByte * keyByte * 0x0F902007)& 0xFFFFFFFF )
             self._ctx = [ctx1, ctx2]
@@ -220,8 +221,9 @@ def _load_python_alfcrypto():
             ctx1 = ctx[0]
             ctx2 = ctx[1]
             plainText = ""
-            for dataChar in data:
-                dataByte = ord(dataChar)
+            if isinstance(data, str):
+                data = data.encode('latin-1')
+            for dataByte in data:
                 m = (dataByte ^ ((ctx1 >> 3) &0xFF) ^ ((ctx2<<3) & 0xFF)) &0xFF
                 ctx2 = ctx1
                 ctx1 = (((ctx1 >> 2) * (ctx1 >> 7)) &0xFFFFFFFF) ^((m * m * 0x0F902007) &0xFFFFFFFF)

--- a/DeDRM_plugin/flatxml2html.py
+++ b/DeDRM_plugin/flatxml2html.py
@@ -473,8 +473,10 @@ class DocParser(object):
                     if (link > 0):
                         linktype = self.link_type[link-1]
                         title = self.link_title[link-1]
-                        if (title == b"") or (parares.rfind(title.decode('utf-8')) < 0):
-                            title=parares[lstart:].encode('utf-8')
+                        if isinstance(title, bytes):
+                            title = title.decode('utf-8')
+                        if (title == "") or (parares.rfind(title) < 0):
+                            title=parares[lstart:]
                         if linktype == 'external' :
                             linkhref = self.link_href[link-1]
                             linkhtml = '<a href="%s">' % linkhref
@@ -485,9 +487,9 @@ class DocParser(object):
                             else :
                                 # just link to the current page
                                 linkhtml = '<a href="#' + self.id + '">'
-                        linkhtml += title.decode('utf-8')
+                        linkhtml += title
                         linkhtml += '</a>'
-                        pos = parares.rfind(title.decode('utf-8'))
+                        pos = parares.rfind(title)
                         if pos >= 0:
                             parares = parares[0:pos] + linkhtml + parares[pos+len(title):]
                         else :

--- a/DeDRM_plugin/topazextract.py
+++ b/DeDRM_plugin/topazextract.py
@@ -178,6 +178,8 @@ def decryptRecord(data,PID):
 # Try to decrypt a dkey record (contains the bookPID)
 def decryptDkeyRecord(data,PID):
     record = decryptRecord(data,PID)
+    if isinstance(record, str):
+       record = record.encode('latin-1')
     fields = unpack('3sB8sB8s3s',record)
     if fields[0] != b'PID' or fields[5] != b'pid' :
         raise DrmException("Didn't find PID magic numbers in record")
@@ -321,6 +323,8 @@ class TopazBook:
                 raise DrmException("Error: Attempt to decrypt without bookKey")
 
         if compressed:
+            if isinstance(record, str):
+                record = bytes(record, 'latin-1')
             record = zlib.decompress(record)
 
         return record
@@ -351,6 +355,8 @@ class TopazBook:
         for pid in pidlst:
             # use 8 digit pids here
             pid = pid[0:8]
+            if isinstance(pid, str):
+                pid = pid.encode('latin-1')
             print("Trying: {0}".format(pid))
             bookKeys = []
             data = keydata
@@ -421,6 +427,8 @@ class TopazBook:
                     outputFile = os.path.join(destdir,fname)
                     print(".", end=' ')
                     record = self.getBookPayloadRecord(name,index)
+                    if isinstance(record, str):
+                        record=bytes(record, 'latin-1')
                     if record != b'':
                         open(outputFile, 'wb').write(record)
                 print(" ")


### PR DESCRIPTION
I've obtained an ebook that can't be decrypted because the code hits the wrong type, bytes/str (see the enclosed log). This isn't happening with all ebooks, so it's possible that the type sometimes is incorrect. I've added tests for the wrong type, and if it is, it will be converted to the other type. This way it should work with both types. With these changes I was able to successfully encrypt the ebook.

[B00194CLJO_log.txt](https://github.com/noDRM/DeDRM_tools/files/7785939/B00194CLJO_log.txt)