### PR TITLE
Add a fallback method for finding libcrypto DLL paths

### DIFF
--- a/DeDRM_plugin/adobekey.py
+++ b/DeDRM_plugin/adobekey.py
@@ -124,17 +124,28 @@ if iswindows:
     except ImportError:
         import _winreg as winreg
 
+    def _licrypto_dll_path():
+        import sys
+        for p in sys.path:
+            if p.endswith("DLLs"):
+                return os.path.join(p, "libcrypto-1_1.dll")
+
+        return
+
     def _load_crypto_libcrypto():
         from ctypes.util import find_library
         libcrypto = find_library('libcrypto-1_1')
         if libcrypto is None:
             libcrypto = find_library('libeay32')
         if libcrypto is None:
+            libcrypto = _licrypto_dll_path()
+        if libcrypto is None:
             raise ADEPTError('libcrypto not found')
         libcrypto = CDLL(libcrypto)
         AES_MAXNR = 14
         c_char_pp = POINTER(c_char_p)
         c_int_p = POINTER(c_int)
+
         class AES_KEY(Structure):
             _fields_ = [('rd_key', c_long * (4 * (AES_MAXNR + 1))),
                         ('rounds', c_int)]


### PR DESCRIPTION
Naively fixes #13 

I call this naive because using the first directory from `sys.path` suffixed with `DLLs` is not what I consider production-worthy. This should be considered nothing more than a proof-of-concept. Note, I have attempted to fix the issue with `find_library` by first calling `os.add_dll_directory` with the path to the system DLLs directory, to no avail. 