### PR TITLE
Obok: Fix invalid UTF-8 causing UI to not open

### DIFF
--- a/Obok_plugin/obok/obok.py
+++ b/Obok_plugin/obok/obok.py
@@ -424,6 +424,7 @@ class KoboLibrary(object):
             olddb.close()
             self.newdb.close()
             self.__sqlite = sqlite3.connect(self.newdb.name)
+            self.__sqlite.text_factory = lambda b: b.decode("utf-8", errors="ignore")
             self.__cursor = self.__sqlite.cursor()
             self._userkeys = []
             self._books = []


### PR DESCRIPTION
For some reason, the title of a book on my device causes Obok to choke. Apparently it's not valid UTF-8.
This PR fixes that by ignoring decode errors.