### PR TITLE
Fix for decription key

### DIFF
--- a/DeDRM_plugin/ineptpdf.py
+++ b/DeDRM_plugin/ineptpdf.py
@@ -427,7 +427,7 @@ def _load_crypto_pycrypto():
             return total
 
         def decrypt(self, data):
-            return _PKCS1_v1_5.new(self._rsa).decrypt(data, 172)
+            return _PKCS1_v1_5.new(self._rsa).decrypt(data, b'')
 
     return (ARC4, RSA, AES)
 
@@ -1901,6 +1901,9 @@ class PDFDocument(object):
         return
 
     def verify_book_key(self, bookkey):
+        if len(bookkey) <= 16:
+            return False
+
         if bookkey[-17] != '\x00' and bookkey[-17] != 0:
             # Byte not null, invalid result
             return False
@@ -1985,12 +1988,11 @@ class PDFDocument(object):
         bookkey = codecs.decode(bookkey.encode('utf-8'),'base64')
         bookkey = rsa.decrypt(bookkey)
 
-        if len(bookkey) > 16:
-            if (self.verify_book_key(bookkey)):
-                bookkey = bookkey[-16:]
-                length = 16
-            else:
-                raise ADEPTError('error decrypting book session key')
+        if (self.verify_book_key(bookkey)):
+            bookkey = bookkey[-16:]
+            length = 16
+        else:
+            raise ADEPTError('error decrypting book session key')
 
         ebx_V = int_value(param.get('V', 4))
         ebx_type = int_value(param.get('EBX_ENCRYPTIONTYPE', 6))


### PR DESCRIPTION
In issue #25 nesoberis commented that Python threw an error when decrypting the key. As j-howell pointed out, this happened because the decrypt command returned value 172 when the decryption failed. This value is incorrect. This fix replaces it with an empty byte string. It also adds a test for an empty byte string, or a key with incorrect length to function verify_book_key, and because of this added test, removes this test by removing line 1988. This should raise an error when decryption of the key fails.