### PR TITLE
Fix for key decryption failure

### DIFF
--- a/DeDRM_plugin/ineptepub.py
+++ b/DeDRM_plugin/ineptepub.py
@@ -329,7 +329,7 @@ def _load_crypto_pycrypto():
             return total
 
         def decrypt(self, data):
-            return _PKCS1_v1_5.new(self._rsa).decrypt(data, 172)
+            return _PKCS1_v1_5.new(self._rsa).decrypt(data, b'')
 
     return (AES, RSA)
 
@@ -466,6 +466,12 @@ def adeptGetUserUUID(inpath):
             return None
 
 def verify_book_key(bookkey):
+    if len(bookkey) < 16:
+        return False
+
+    if len(bookkey) == 16:
+        return True
+
     if bookkey[-17] != '\x00' and bookkey[-17] != 0:
         # Byte not null, invalid result
         return False
@@ -523,13 +529,13 @@ def decryptBook(userkey, inpath, outpath):
                 bookkey = rsa.decrypt(base64.b64decode(bookkey.encode('ascii')))
 
                 # Verify key:
-                if len(bookkey) > 16:
-                    # Padded as per RSAES-PKCS1-v1_5
-                    if verify_book_key(bookkey):
+                if verify_book_key(bookkey):
+                    if len(bookkey) > 16:
+                        # Padded as per RSAES-PKCS1-v1_5
                         bookkey = bookkey[-16:]
-                    else:
-                        print("Could not decrypt {0:s}. Wrong key".format(os.path.basename(inpath)))
-                        return 2
+                else:
+                    print("Could not decrypt {0:s}. Wrong key".format(os.path.basename(inpath)))
+                    return 2
             else: 
                 # Adobe PassHash / B&N
                 key = base64.b64decode(userkey)[:16]

--- a/DeDRM_plugin/ineptpdf.py
+++ b/DeDRM_plugin/ineptpdf.py
@@ -427,7 +427,7 @@ def _load_crypto_pycrypto():
             return total
 
         def decrypt(self, data):
-            return _PKCS1_v1_5.new(self._rsa).decrypt(data, 172)
+            return _PKCS1_v1_5.new(self._rsa).decrypt(data, b'')
 
     return (ARC4, RSA, AES)
 
@@ -1901,6 +1901,12 @@ class PDFDocument(object):
         return
 
     def verify_book_key(self, bookkey):
+        if len(bookkey) < 16:
+            return False
+
+        if len(bookkey) == 16:
+            return True
+
         if bookkey[-17] != '\x00' and bookkey[-17] != 0:
             # Byte not null, invalid result
             return False
@@ -1985,12 +1991,12 @@ class PDFDocument(object):
         bookkey = codecs.decode(bookkey.encode('utf-8'),'base64')
         bookkey = rsa.decrypt(bookkey)
 
+        if not self.verify_book_key(bookkey):
+            raise ADEPTError('error decrypting book session key')
+
         if len(bookkey) > 16:
-            if (self.verify_book_key(bookkey)):
-                bookkey = bookkey[-16:]
-                length = 16
-            else:
-                raise ADEPTError('error decrypting book session key')
+            bookkey = bookkey[-16:]
+            length = 16
 
         ebx_V = int_value(param.get('V', 4))
         ebx_type = int_value(param.get('EBX_ENCRYPTIONTYPE', 6))


### PR DESCRIPTION
When converting a PDF, if the key that's been retrieved can't be decrypted, the integer 172 is returned. As j-howell has pointed out, this value is incorrect, because the length of the result is tested, which causes a runtime error if the result is an integer. This fix returns an empty byte string instead, and uses the length of the result to determine if the key has failed to decrypt, in which case an error will be raised. Note that the PDF can't be converted anyhow, as the key can't be decrypted, but with this fix the conversion shouldn't crash with a runtime error, but instead point out why it has failed.