### PR TITLE
Fix Obok import in Calibre flatpak by using /sys/class/net/IFACE/address instead of `ip`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,3 @@
 # Cache
 /DeDRM_plugin/__pycache__
 /DeDRM_plugin/standalone/__pycache__
-
-# zip from make_release.py
-/DeDRM_tools.zip

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 # Cache
 /DeDRM_plugin/__pycache__
 /DeDRM_plugin/standalone/__pycache__
+
+# zip from make_release.py
+/DeDRM_tools.zip

--- a/Obok_plugin/obok/obok.py
+++ b/Obok_plugin/obok/obok.py
@@ -449,9 +449,15 @@ class KoboLibrary(object):
             for m in matches:
                 # print "m:{0}".format(m[0])
                 macaddrs.append(m[0].upper())
+        elif sys.platform.startswith('linux'):
+            for interface in os.listdir('/sys/class/net'):
+                with open('/sys/class/net/' + interface + '/address', 'r') as f:
+                    mac = f.read().strip().upper()
+                # some interfaces, like Tailscale's VPN interface, do not have a MAC address
+                if mac != '':
+                    macaddrs.append(mac)
         else:
-            # probably linux
-
+            # final fallback
             # let's try ip
             c = re.compile('\s(' + '[0-9a-f]{2}:' * 5 + '[0-9a-f]{2})(\s|$)', re.IGNORECASE)
             for line in os.popen('ip -br link'):


### PR DESCRIPTION
Fixes #585 by using `/sys/class/net/IFACE/address` for the MAC address instead of the `ip` command. I left the old Linux method of `ip` and `ipconfig` as an ultimate fallback, but I'm not sure if it's going to be useful.

After making this change I was able to successfully import a DRM'd Kobo book from the Calibre flatpak. I should note I can only test in Calibre 7.