### PR TITLE
Correct improper decryption of PDFStream object in Adobe Digital Edition PDF

### DIFF
--- a/DeDRM_plugin/ineptpdf.py
+++ b/DeDRM_plugin/ineptpdf.py
@@ -914,6 +914,7 @@ class PDFStream(PDFObject):
         self.decipher = decipher
         self.data = None
         self.decdata = None
+        self.decdic = None
         self.objid = None
         self.genno = None
         return

--- a/DeDRM_plugin/ineptpdf.py
+++ b/DeDRM_plugin/ineptpdf.py
@@ -52,13 +52,14 @@
 #   10.0.0 - Add support for "hardened" Adobe DRM (RMSDK >= 10)
 #   10.0.2 - Fix some Python2 stuff
 #   10.0.4 - Fix more Python2 stuff
+#   10.0.5 - modified PDFStream object to decrypt included dictionary
 
 """
 Decrypts Adobe ADEPT-encrypted PDF files.
 """
 
 __license__ = 'GPL v3'
-__version__ = "10.0.4"
+__version__ = "10.0.5"
 
 import codecs
 import hashlib


### PR DESCRIPTION
The original code fails to decrypt the dictionary object within the stream object, decrypting only the data contained within the stream and not the remaining dictionary portion of the stream object. This leads to improper decryption of images with an Indexed colorspace where the lookup table is stored as an encrypted string within the dictionary of the stream object.

This change allows the decryption of the remaining data within the stream object , stored as a dictionary, and fixes the color issue that plagued encrypted PDFs with Indexed images.

The impetus for correcting this came from a PDF with images whose color was corrupted, but there may be other cases where issues have arisen due to significant information within the stream object not being properly decrypted. This change applies to the stream object and will resolve issues in those cases as well.